### PR TITLE
Migrate onboarding to spec-driven workflow

### DIFF
--- a/frontend/components/onboarding/steps/CompleteStep.tsx
+++ b/frontend/components/onboarding/steps/CompleteStep.tsx
@@ -117,7 +117,7 @@ export function CompleteStep() {
             </>
           ) : data.firstSpecId ? (
             <>
-              Watch Agent Progress
+              View Spec Progress
               <ArrowRight className="ml-2 h-5 w-5" />
             </>
           ) : (


### PR DESCRIPTION
## Summary
Refactors the onboarding flow to use the spec-driven workflow instead of direct sandbox creation. This ensures new users experience the full planning and execution pipeline (requirements → design → tasks → sync) rather than jumping directly to sandbox execution.

## Key Changes
- **API Migration**: Changed from `/api/v1/sandboxes` to `/api/v1/specs` endpoint for creating and monitoring the initial spec
- **Spec Status Tracking**: Updated `checkSpecStatus()` to poll the spec endpoint and check for completion via `current_phase` field (complete or sync phase indicates PR creation)
- **Workflow Integration**: Replaced direct sandbox creation with `launchSpec()` function call, enabling the full spec-driven workflow with `auto_execute: true` to start sandbox execution after planning
- **Navigation**: Updated redirect to point to spec detail page (`/projects/{projectId}/specs/{specId}`) instead of board view
- **UI Label**: Changed button text from "Watch Agent Progress" to "View Spec Progress" for clarity
- **Validation**: Added project ID validation before spec creation to prevent errors

## Implementation Details
- The `firstSpecId` now refers to a spec ID rather than a sandbox ID, maintaining consistency with the spec-driven architecture
- Spec completion is determined by reaching either the "complete" or "sync" phase, with "sync" indicating a PR has been created
- The `auto_execute` flag ensures the sandbox starts immediately after the spec planning phase completes, maintaining the seamless user experience